### PR TITLE
Bump Cargo.toml version to 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pivx-shielding"
 version = "0.1.0"
 authors = ["Duddino <duddino@duddino.com>", "Alessandro Rezzi <alessandrorezzi2000@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
Not sure why we were on 2018, `wasm-pack build` runs fine and all tests pass