### PR TITLE
Multicore support

### DIFF
--- a/#Cargo.toml#
+++ b/#Cargo.toml#
@@ -12,16 +12,15 @@ default = ["console_error_panic_hook"]
 
 [dependencies]
 lazy_static = "1.4.0"
-rayon = "1.5"
 async_once = "0.2.6"
 sha256 = "1.1.2"
 getrandom = { version = "0.2", features = ["js"] }
 reqwest = { version = "0.11.14", features = ["blocking"] }
-wasm-bindgen = "0.2.74"
+wasm-bindgen = "0.2.63"
 wasm-bindgen-futures = "0.4.34"
-pivx_client_backend = { git = "https://github.com/Duddino/librustpivx" }
-pivx_primitives = { git = "https://github.com/Duddino/librustpivx", features = ["transparent-inputs"] }
-pivx_proofs = { git = "https://github.com/Duddino/librustpivx" }
+pivx_client_backend = { git = "https://github.com/Duddino/librustpvix" }
+pivx_primitives = { git = "https://github.com/Duddino/librustpvix", features = ["transparent-inputs"] }
+pivx_proofs = { git = "https://github.com/Duddino/librustpvix", default-features = false, features = ["local-prover"] }
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.4.5"
 serde_json = "1.0.93"
@@ -40,7 +39,6 @@ wee_alloc = { version = "0.4.5", optional = true }
 rand_core = "0.6.4"
 secp256k1 = "0.21"
 either = "1.8.1"
-wasm-bindgen-rayon = "1.0.3"
 
 [dev-dependencies]
 tokio = { version = "1.26.0", features = ["full"] } 

--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,5 @@
+[target.wasm32-unknown-unknown]
+rustflags = ["-C", "target-feature=+atomics,+bulk-memory,+mutable-globals"]
+
+[unstable]
+build-std = ["panic_abort", "std"]

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 Cargo.lock
 bin/
 pkg/
+pkg_multicore/
 wasm-pack.log
 js/node_modules

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 default = ["console_error_panic_hook"]
+multicore = ["pivx_proofs/multicore", "wasm-bindgen-rayon"]
 
 [dependencies]
 lazy_static = "1.4.0"
@@ -20,7 +21,7 @@ reqwest = { version = "0.11.14", features = ["blocking"] }
 wasm-bindgen = "0.2.74"
 wasm-bindgen-futures = "0.4.34"
 pivx_client_backend = { git = "https://github.com/Duddino/librustpivx" }
-pivx_primitives = { git = "https://github.com/Duddino/librustpivx", features = ["transparent-inputs"] }
+pivx_primitives = { git = "https://github.com/Duddino/librustpivx", default-features = false, features = ["transparent-inputs"] }
 pivx_proofs = { git = "https://github.com/Duddino/librustpivx" }
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.4.5"
@@ -40,7 +41,7 @@ wee_alloc = { version = "0.4.5", optional = true }
 rand_core = "0.6.4"
 secp256k1 = "0.21"
 either = "1.8.1"
-wasm-bindgen-rayon = "1.0.3"
+wasm-bindgen-rayon = { version = "1.0.3", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.26.0", features = ["full"] } 

--- a/build_multicore.sh
+++ b/build_multicore.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
 rustup override set nightly;
-wasm-pack build --target web -- --config "build-std = [\"panic_abort\", \"std\"]" --features="multicore";
+wasm-pack build --target web --out-dir pkg_multicore -- --config "build-std = [\"panic_abort\", \"std\"]" --features="multicore";
+sed -i 's/pivx-shielding/pivx-shielding-multicore/' pkg_multicore/package.json 
 rustup override set stable;

--- a/build_multicore.sh
+++ b/build_multicore.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+rustup override set nightly;
+wasm-pack build --target web -- --config "build-std = [\"panic_abort\", \"std\"]" --features="multicore";
+rustup override set stable;

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -10,8 +10,10 @@
       "license": "ISC",
       "dependencies": {
         "bs58": "^5.0.0",
+        "comlink": "^4.4.1",
         "pivx-shielding": "file:../pkg/",
-        "typescript": "^4.9.5"
+        "typescript": "^4.9.5",
+        "wasm-feature-detect": "^1.5.1"
       }
     },
     "../pkg": {
@@ -31,6 +33,11 @@
         "base-x": "^4.0.0"
       }
     },
+    "node_modules/comlink": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.4.1.tgz",
+      "integrity": "sha512-+1dlx0aY5Jo1vHy/tSsIGpSkN4tS9rZSW8FIhG0JH/crs9wwweswIo/POr451r7bZww3hFbPAKnTpimzL/mm4Q=="
+    },
     "node_modules/pivx-shielding": {
       "resolved": "../pkg",
       "link": true
@@ -46,6 +53,11 @@
       "engines": {
         "node": ">=4.2.0"
       }
+    },
+    "node_modules/wasm-feature-detect": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.5.1.tgz",
+      "integrity": "sha512-GHr23qmuehNXHY4902/hJ6EV5sUANIJC3R/yMfQ7hWDg3nfhlcJfnIL96R2ohpIwa62araN6aN4bLzzzq5GXkg=="
     }
   }
 }

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -12,12 +12,16 @@
         "bs58": "^5.0.0",
         "comlink": "^4.4.1",
         "pivx-shielding": "file:../pkg/",
+        "pivx-shielding-multicore": "file:../pkg_multicore",
         "typescript": "^4.9.5",
         "wasm-feature-detect": "^1.5.1"
       }
     },
     "../pkg": {
       "name": "pivx-shielding",
+      "version": "0.1.0"
+    },
+    "../pkg_multicore": {
       "version": "0.1.0"
     },
     "node_modules/base-x": {
@@ -40,6 +44,10 @@
     },
     "node_modules/pivx-shielding": {
       "resolved": "../pkg",
+      "link": true
+    },
+    "node_modules/pivx-shielding-multicore": {
+      "resolved": "../pkg_multicore",
       "link": true
     },
     "node_modules/typescript": {

--- a/js/package.json
+++ b/js/package.json
@@ -14,6 +14,7 @@
     "bs58": "^5.0.0",
     "comlink": "^4.4.1",
     "pivx-shielding": "file:../pkg/",
+    "pivx-shielding-multicore": "file:../pkg_multicore",
     "typescript": "^4.9.5",
     "wasm-feature-detect": "^1.5.1"
   },

--- a/js/package.json
+++ b/js/package.json
@@ -3,14 +3,19 @@
   "version": "1.0.0",
   "description": "",
   "main": "pivx_shielding.js",
+  "files": [
+    "start_worker.js"
+  ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "tsc --allowJs -d --emitDeclarationOnly pivx_shielding.js"
   },
   "dependencies": {
     "bs58": "^5.0.0",
+    "comlink": "^4.4.1",
     "pivx-shielding": "file:../pkg/",
-    "typescript": "^4.9.5"
+    "typescript": "^4.9.5",
+    "wasm-feature-detect": "^1.5.1"
   },
   "author": "",
   "license": "ISC"

--- a/js/pivx_shielding.d.ts
+++ b/js/pivx_shielding.d.ts
@@ -17,12 +17,15 @@ export class PIVXShielding {
         accountIndex: number;
         loadSaplingData: boolean;
     }): Promise<PIVXShielding>;
-    constructor(shieldMan: any, extsk: any, isTestNet: any, nHeight: any, commitmentTree: any);
+    constructor(shieldWorker: any, extsk: any, isTestNet: any, nHeight: any, commitmentTree: any);
+    initWorker(): void;
+    promises: any;
+    callWorker(name: any, ...args: any[]): Promise<any>;
     /**
      * Webassembly object that holds Shield related functions
      * @private
      */
-    private shieldMan;
+    private shieldWorker;
     /**
      * Extended spending key
      * @type {String}
@@ -75,12 +78,12 @@ export class PIVXShielding {
      * Adds a transaction to the tree. Decrypts notes and stores nullifiers
      * @param {String} hex - transaction hex
      */
-    addTransaction(hex: string): void;
+    addTransaction(hex: string): Promise<void>;
     /**
      * Remove the Shield Notes that match the nullifiers given in input
      * @param {Array<String>} blockJson - Array of nullifiers
      */
-    removeSpentNotes(nullifiers: any): void;
+    removeSpentNotes(nullifiers: any): Promise<void>;
     /**
      * Return number of shielded satoshis of the account
      */
@@ -118,7 +121,7 @@ export class PIVXShielding {
      * @returns {String} new shielded address
      */
     getNewAddress(): string;
-    loadSaplingProver(): Promise<any>;
+    loadSaplingProver(): Promise<boolean>;
     /**
      * @returns {Number} The last block that has been decoded
      */

--- a/js/pivx_shielding.d.ts
+++ b/js/pivx_shielding.d.ts
@@ -73,7 +73,7 @@ export class PIVXShielding {
     handleBlock(blockJson: {
         txs: string[];
         height: number;
-    }): void;
+    }): Promise<void>;
     /**
      * Adds a transaction to the tree. Decrypts notes and stores nullifiers
      * @param {String} hex - transaction hex
@@ -121,7 +121,7 @@ export class PIVXShielding {
      * @returns {String} new shielded address
      */
     getNewAddress(): string;
-    loadSaplingProver(): Promise<boolean>;
+    loadSaplingProver(): Promise<any>;
     /**
      * @returns {Number} The last block that has been decoded
      */

--- a/js/pivx_shielding.d.ts
+++ b/js/pivx_shielding.d.ts
@@ -109,7 +109,7 @@ export class PIVXShielding {
      * @throws Error if txid is not found
      * @param{String} txid - Transaction id
      */
-    finalizeTransaction(txid: string): void;
+    finalizeTransaction(txid: string): Promise<void>;
     /**
      * Discards the transaction, for example if
      * there were errors in sending them.

--- a/js/pivx_shielding.js
+++ b/js/pivx_shielding.js
@@ -269,8 +269,8 @@ export class PIVXShielding {
     return address;
   }
 
-    async loadSaplingProver() {
-	return await this.callWorker("load_prover");
+  async loadSaplingProver() {
+    return await this.callWorker("load_prover");
   }
 
   /**

--- a/js/pivx_shielding.js
+++ b/js/pivx_shielding.js
@@ -7,9 +7,9 @@ export class PIVXShielding {
     this.shieldWorker.onmessage = (msg) => {
       const { res, rej } = this.promises.get(msg.data.uuid);
       if (msg.data.rej) {
-	rej(msg.data.rej);
+        rej(msg.data.rej);
       } else {
-	res(msg.data.res);
+        res(msg.data.res);
       }
       this.promises.delete(msg.data.uuid);
     };
@@ -266,10 +266,10 @@ export class PIVXShielding {
   async getNewAddress() {
     const { address, diversifier_index } = await this.callWorker(
       "generate_next_shielding_payment_address",
-        this.extsk,
-        this.diversifierIndex,
-        this.isTestNet
-      );
+      this.extsk,
+      this.diversifierIndex,
+      this.isTestNet
+    );
     this.diversifierIndex = diversifier_index;
     return address;
   }

--- a/js/pivx_shielding.js
+++ b/js/pivx_shielding.js
@@ -142,14 +142,14 @@ export class PIVXShielding {
    * Loop through the txs of a block and update useful shield data
    * @param {{txs: String[], height: Number}} blockJson - Json of the block outputted from any PIVX node
    */
-  handleBlock(blockJson) {
+  async handleBlock(blockJson) {
     if (this.lastProcessedBlock > blockJson.height) {
       throw new Error(
         "Blocks must be processed in a monotonically increasing order!"
       );
     }
     for (const tx of blockJson.txs) {
-      this.addTransaction(tx.hex);
+      await this.addTransaction(tx.hex);
     }
     this.lastProcessedBlock = blockJson.height;
   }
@@ -170,7 +170,7 @@ export class PIVXShielding {
     this.unspentNotes = res.decrypted_notes;
 
     if (res.nullifiers.length > 0) {
-      this.removeSpentNotes(res.nullifiers);
+      await this.removeSpentNotes(res.nullifiers);
     }
   }
 
@@ -240,9 +240,9 @@ export class PIVXShielding {
    * @throws Error if txid is not found
    * @param{String} txid - Transaction id
    */
-  finalizeTransaction(txid) {
+  async finalizeTransaction(txid) {
     const nullifiers = this.pendingSpentNotes.get(txid);
-    this.removeSpentNotes(nullifiers);
+    await this.removeSpentNotes(nullifiers);
     this.discardTransaction(txid);
   }
   /**
@@ -269,8 +269,8 @@ export class PIVXShielding {
     return address;
   }
 
-  async loadSaplingProver() {
-    return true; //await this.shieldMan.load_prover();
+    async loadSaplingProver() {
+	return await this.callWorker("load_prover");
   }
 
   /**

--- a/js/pivx_shielding.js
+++ b/js/pivx_shielding.js
@@ -5,7 +5,12 @@ export class PIVXShielding {
   initWorker() {
     this.promises = new Map();
     this.shieldWorker.onmessage = (msg) => {
-      this.promises.get(msg.data.uuid).res(msg.data.res);
+      const { res, rej } = this.promises.get(msg.data.uuid);
+      if (msg.data.rej) {
+	rej(msg.data.rej);
+      } else {
+	res(msg.data.res);
+      }
       this.promises.delete(msg.data.uuid);
     };
   }

--- a/js/worker_start.js
+++ b/js/worker_start.js
@@ -1,9 +1,15 @@
-import init, * as shieldMan from "pivx-shielding";
+import { threads } from 'wasm-feature-detect';
+let shieldMan = null;
 
 const start = async () => {
-  await init();
-  if (shieldMan.initThreadPool)  
+  if (await threads()) {
+    shieldMan = await import('pivx-shielding-multicore');
+    await shieldMan.default();
     await shieldMan.initThreadPool(navigator.hardwareConcurrency);
+  } else {
+    shieldMan = await import('pivx-shielding');
+    await shieldMan.default();
+  }
   self.postMessage("done");
 };
 

--- a/js/worker_start.js
+++ b/js/worker_start.js
@@ -1,13 +1,13 @@
-import { threads } from 'wasm-feature-detect';
+import { threads } from "wasm-feature-detect";
 let shieldMan = null;
 
 const start = async () => {
   if (await threads()) {
-    shieldMan = await import('pivx-shielding-multicore');
+    shieldMan = await import("pivx-shielding-multicore");
     await shieldMan.default();
     await shieldMan.initThreadPool(navigator.hardwareConcurrency);
   } else {
-    shieldMan = await import('pivx-shielding');
+    shieldMan = await import("pivx-shielding");
     await shieldMan.default();
   }
   self.postMessage("done");

--- a/js/worker_start.js
+++ b/js/worker_start.js
@@ -1,0 +1,20 @@
+import init, * as shieldMan from 'pivx-shielding';
+
+const start = async () => {
+    await init();
+    await shieldMan.initThreadPool(navigator.hardwareConcurrency);
+    self.postMessage('done');
+}
+start();
+
+self.onmessage = async (msg) => {
+    console.log("Doing work!");
+    console.log(msg.data);
+    try {
+	const res = await shieldMan.create_transaction(msg.data);
+	console.log(res);
+    } catch (e) {
+	console.log("Work failed :(");
+	console.error(e);
+    }
+}

--- a/js/worker_start.js
+++ b/js/worker_start.js
@@ -11,9 +11,9 @@ start();
 self.onmessage = async (msg) => {
   const { uuid, name, args } = msg.data;
 
-    try {
-	const res = await shieldMan[name](...args);
-	self.postMessage({ uuid, res });
+  try {
+    const res = await shieldMan[name](...args);
+    self.postMessage({ uuid, res });
   } catch (e) {
     self.postMessage({ uuid, res: false });
     console.log("Work failed :(");

--- a/js/worker_start.js
+++ b/js/worker_start.js
@@ -2,7 +2,8 @@ import init, * as shieldMan from "pivx-shielding";
 
 const start = async () => {
   await init();
-  await shieldMan.initThreadPool(navigator.hardwareConcurrency);
+  if (shieldMan.initThreadPool)  
+    await shieldMan.initThreadPool(navigator.hardwareConcurrency);
   self.postMessage("done");
 };
 
@@ -15,8 +16,7 @@ self.onmessage = async (msg) => {
     const res = await shieldMan[name](...args);
     self.postMessage({ uuid, res });
   } catch (e) {
-    self.postMessage({ uuid, res: false });
-    console.log("Work failed :(");
-    console.error(e);
+    self.postMessage({ uuid, rej: e });
+    throw e;
   }
 };

--- a/js/worker_start.js
+++ b/js/worker_start.js
@@ -1,20 +1,22 @@
-import init, * as shieldMan from 'pivx-shielding';
+import init, * as shieldMan from "pivx-shielding";
 
 const start = async () => {
-    await init();
-    await shieldMan.initThreadPool(navigator.hardwareConcurrency);
-    self.postMessage('done');
-}
+  await init();
+  await shieldMan.initThreadPool(navigator.hardwareConcurrency);
+  self.postMessage("done");
+};
 start();
 
 self.onmessage = async (msg) => {
-    console.log("Doing work!");
-    console.log(msg.data);
-    try {
-	const res = await shieldMan.create_transaction(msg.data);
-	console.log(res);
-    } catch (e) {
-	console.log("Work failed :(");
-	console.error(e);
-    }
-}
+  console.log("Doing work!");
+  const { uuid, name, args } = msg.data;
+
+  try {
+    const res = await shieldMan[name](...args);
+    self.postMessage({ uuid, res });
+  } catch (e) {
+    self.postMessage({ uuid, res: false });
+    console.log("Work failed :(");
+    console.error(e);
+  }
+};

--- a/js/worker_start.js
+++ b/js/worker_start.js
@@ -5,15 +5,15 @@ const start = async () => {
   await shieldMan.initThreadPool(navigator.hardwareConcurrency);
   self.postMessage("done");
 };
+
 start();
 
 self.onmessage = async (msg) => {
-  console.log("Doing work!");
   const { uuid, name, args } = msg.data;
 
-  try {
-    const res = await shieldMan[name](...args);
-    self.postMessage({ uuid, res });
+    try {
+	const res = await shieldMan[name](...args);
+	self.postMessage({ uuid, res });
   } catch (e) {
     self.postMessage({ uuid, res: false });
     console.log("Work failed :(");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,8 @@ mod utils;
 #[global_allocator]
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
-pub use wasm_bindgen_rayon::init_thread_pool;
 use wasm_bindgen::prelude::*;
+pub use wasm_bindgen_rayon::init_thread_pool;
 
 #[wasm_bindgen(start)]
 pub fn run() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,3 +6,11 @@ mod utils;
 #[cfg(feature = "wee_alloc")]
 #[global_allocator]
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
+
+pub use wasm_bindgen_rayon::init_thread_pool;
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen(start)]
+pub fn run() {
+    utils::set_panic_hook();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ mod utils;
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
 use wasm_bindgen::prelude::*;
+#[cfg(feature = "multicore")]
 pub use wasm_bindgen_rayon::init_thread_pool;
 
 #[wasm_bindgen(start)]


### PR DESCRIPTION
Adds multicore support. The feature will only be enabled if the browser supports it. 
To build with multicore, run the script
`./build_multicore.sh`.
To build without,
`wasm-pack --target web`.
Both should be built to make sure the browser can fetch the one it needs.

On MPW side, the following headers should be set on the dev server:
```js
headers: {
	    "Cross-Origin-Embedder-Policy": "require-corp",
	    "Cross-Origin-Opener-Policy": "same-origin",	
}
```

Closes #27

 