### PR TITLE
Cargo.toml cleanups

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ console_error_panic_hook = { version = "0.1.6", optional = true }
 secp256k1 = "0.21"
 either = "1.8.1"
 wasm-bindgen-rayon = { version = "1.0.3", optional = true }
+rand_core = "0.6.4"
 
 [dev-dependencies]
 tokio = { version = "1.26.0", features = ["full"] } 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ multicore = ["pivx_proofs/multicore", "wasm-bindgen-rayon"]
 
 [dependencies]
 lazy_static = "1.4.0"
-rayon = "1.5"
 async_once = "0.2.6"
 sha256 = "1.1.2"
 getrandom = { version = "0.2", features = ["js"] }
@@ -34,11 +33,6 @@ hex = "0.4.3"
 # code size when deploying.
 console_error_panic_hook = { version = "0.1.6", optional = true }
 
-# `wee_alloc` is a tiny allocator for wasm that is only ~1K in code size
-# compared to the default allocator's ~10K. It is slower than the default
-# allocator, however.
-wee_alloc = { version = "0.4.5", optional = true }
-rand_core = "0.6.4"
 secp256k1 = "0.21"
 either = "1.8.1"
 wasm-bindgen-rayon = { version = "1.0.3", optional = true }
@@ -49,7 +43,9 @@ wasm-bindgen-test = "0.3.13"
 
 [profile.release]
 # Tell `rustc` to optimize for small code size.
-opt-level = "s"
+opt-level = 3
+lto = true
 
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = false
+wasm-opt = true
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,12 +2,8 @@ mod checkpoint;
 mod keys;
 mod transaction;
 mod utils;
-
-#[cfg(feature = "wee_alloc")]
-#[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
-
 use wasm_bindgen::prelude::*;
+
 #[cfg(feature = "multicore")]
 pub use wasm_bindgen_rayon::init_thread_pool;
 


### PR DESCRIPTION
This PR:
- Removes unused libraries: rayon
- Completely removes wee_alloc as it's no longer being mantained (It was already disabled by default)
- Enables more optimazations in release mode (The proof creation for a tx with 7 inputs went from 2 minutes to 80 seconds on my machine)