### PR TITLE
Fix max balance

### DIFF
--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -468,7 +468,7 @@ fn choose_utxos(
         }
     }
     if total < *amount + fee {
-        if total > *amount {
+        if total >= *amount {
             *amount -= fee;
         } else {
             Err("Not enough balance")?;
@@ -523,7 +523,7 @@ fn choose_notes(
     }
 
     if total < *amount + fee {
-        if total > *amount {
+        if total >= *amount {
             *amount -= fee
         } else {
             Err("Not enough balance")?;


### PR DESCRIPTION
When the balance what exactly equal tot he amount it threw an error.

After [this](https://testnet.rockdev.org/tx/2472e51a8ebf6f6091f6995fe48de628266ed1bacb85035b4d202300e2ed6bf9) transaction on MPW, I was able to get the shield balance to exactly 0
