### PR TITLE
Return Result everywhere

### DIFF
--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -116,7 +116,6 @@ mod test {
 
 //Output the closest checkpoint to a given blockheight
 #[wasm_bindgen]
-pub fn get_closest_checkpoint(block_height: i32, is_testnet: bool) -> JsValue {
-    return serde_wasm_bindgen::to_value(&get_checkpoint(block_height, is_testnet))
-        .expect("Cannot serialize checkpoint");
+pub fn get_closest_checkpoint(block_height: i32, is_testnet: bool) -> Result<JsValue, JsValue> {
+    Ok(serde_wasm_bindgen::to_value(&get_checkpoint(block_height, is_testnet))?)
 }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -46,14 +46,14 @@ pub fn decode_generic_address(
         Ok(GenericAddress::Transparent(to_address))
     }
 }
-pub fn decode_extsk(enc_extsk: &str, is_testnet: bool) -> ExtendedSpendingKey {
+pub fn decode_extsk(enc_extsk: &str, is_testnet: bool) -> Result<ExtendedSpendingKey, Box<dyn Error>> {
     let enc_str: &str = if is_testnet {
         TEST_NETWORK.hrp_sapling_extended_spending_key()
     } else {
         MAIN_NETWORK.hrp_sapling_extended_spending_key()
     };
 
-    encoding::decode_extended_spending_key(enc_str, enc_extsk).expect("Cannot decde extsk")
+    Ok(encoding::decode_extended_spending_key(enc_str, enc_extsk).map_err(|_| "Cannot decde extsk")?)
 }
 
 pub fn encode_extsk(extsk: &ExtendedSpendingKey, is_testnet: bool) -> String {
@@ -77,16 +77,15 @@ pub fn encode_payment_address(addr: &PaymentAddress, is_testnet: bool) -> String
 
 //Generate an extended spending key given a seed, coin type and account index
 #[wasm_bindgen]
-pub fn generate_extended_spending_key_from_seed(val: JsValue) -> JsValue {
-    let data_arr: JSExtendedSpendingKeySerData = serde_wasm_bindgen::from_value(val)
-        .expect("Cannot deserialize seed/coin type/ account index");
+pub fn generate_extended_spending_key_from_seed(val: JsValue) -> Result<JsValue, JsValue> {
+    let data_arr: JSExtendedSpendingKeySerData = serde_wasm_bindgen::from_value(val)?;
     let extsk = sapling::spending_key(
         &data_arr.seed,
         data_arr.coin_type,
         AccountId::from(data_arr.account_index),
     );
     let enc_extsk = encode_extsk(&extsk, data_arr.coin_type == 1);
-    serde_wasm_bindgen::to_value(&enc_extsk).expect("Cannot serialize extended spending key")
+    Ok(serde_wasm_bindgen::to_value(&enc_extsk)?)
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -96,14 +95,13 @@ struct NewAddress {
 }
 //Generate the deafult address of a given encoded extended full viewing key
 #[wasm_bindgen]
-pub fn generate_default_payment_address(enc_extsk: String, is_testnet: bool) -> JsValue {
-    let extsk = decode_extsk(&enc_extsk, is_testnet);
+pub fn generate_default_payment_address(enc_extsk: String, is_testnet: bool) -> Result<JsValue, JsValue> {
+    let extsk = decode_extsk(&enc_extsk, is_testnet).map_err(|e| e.to_string())?;
     let (def_index, def_address) = extsk.to_diversifiable_full_viewing_key().default_address();
-    serde_wasm_bindgen::to_value(&NewAddress {
+    Ok(serde_wasm_bindgen::to_value(&NewAddress {
         address: encode_payment_address(&def_address, is_testnet),
         diversifier_index: def_index.0.to_vec(),
-    })
-    .expect("Failed to encode")
+    })?)
 }
 // Generate the n_address-th valid payment address given the encoded extended full viewing key and a starting index
 #[wasm_bindgen]
@@ -111,24 +109,23 @@ pub fn generate_next_shielding_payment_address(
     enc_extsk: String,
     diversifier_index: &[u8],
     is_testnet: bool,
-) -> JsValue {
-    let extsk = decode_extsk(&enc_extsk, is_testnet);
+) -> Result<JsValue, JsValue> {
+    let extsk = decode_extsk(&enc_extsk, is_testnet).map_err(|e| e.to_string())?;
     let mut diversifier_index = DiversifierIndex(
         diversifier_index
             .try_into()
-            .expect("Invalid diversifier index"),
+            .map_err(|_| "Invalid diversifier index")?,
     );
     diversifier_index
         .increment()
-        .expect("No valid indeces left");
+        .map_err(|_| "No valid indeces left")?;
     let (new_index, address) = extsk
         .to_diversifiable_full_viewing_key()
         .find_address(diversifier_index)
-        .expect("No valid indeces left"); // There are so many valid addresses this should never happen
+        .ok_or("No valid indeces left")?; // There are so many valid addresses this should never happen
 
-    serde_wasm_bindgen::to_value(&NewAddress {
+    Ok(serde_wasm_bindgen::to_value(&NewAddress {
         address: encode_payment_address(&address, is_testnet),
         diversifier_index: new_index.0.to_vec(),
-    })
-    .expect("Failed to decode")
+    })?)
 }


### PR DESCRIPTION
panic! (Called by unwrap and expect) were causing unrecoverable errors that could not be catched with a try-catch block. This changes pretty much every function to return `Result<JsValue, JsValue>`.
If the value returned is an Err(), Javascript will throw an exception, which will then reject the promise
