### PR TITLE
Improve sync time

### DIFF
--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -4,6 +4,7 @@ use crate::prover::get_prover;
 use crate::prover::ImplTxProver;
 use incrementalmerkletree::frontier::CommitmentTree;
 use incrementalmerkletree::witness::IncrementalWitness;
+use pivx_client_backend::data_api::DecryptedTransaction;
 use pivx_client_backend::decrypt_transaction;
 use pivx_client_backend::keys::UnifiedFullViewingKey;
 use pivx_primitives::consensus::Network;
@@ -40,6 +41,8 @@ use zcash_transparent::bundle::{OutPoint, TxOut};
 
 #[cfg(feature = "multicore")]
 use pivx_primitives::transaction::builder::Progress;
+#[cfg(feature = "multicore")]
+use rayon::prelude::*;
 use sapling::NullifierDerivingKey;
 use secp256k1::SecretKey;
 use serde::{Deserialize, Serialize};
@@ -55,6 +58,20 @@ mod test;
 
 #[cfg(feature = "multicore")]
 static TX_PROGRESS_LOCK: AtomicF32 = AtomicF32::new(0.0);
+
+#[cfg(feature = "multicore")]
+macro_rules! maybe_iter {
+    ($v:expr) => {
+        $v.par_iter()
+    };
+}
+
+#[cfg(not(feature = "multicore"))]
+macro_rules! maybe_iter {
+    ($v:expr) => {
+        $v.iter()
+    };
+}
 
 pub const DEPTH: u8 = 32;
 
@@ -170,36 +187,65 @@ pub fn handle_blocks(
         .map(|n| SpendableNote::from_js_spendable_note(n))
         .collect::<Result<Vec<SpendableNote>, _>>()
         .map_err(|e| e.to_string())?;
+    let txs = blocks.into_iter().flat_map(|b| b.txs).collect::<Vec<_>>();
+
+    let mut hash = HashMap::new();
+    let nullif_key = key
+        .sapling()
+        .ok_or("Cannot generate nullifier key")?
+        .to_nk(Scope::External);
+    hash.insert(AccountId::default(), key.clone());
+    let txs = txs
+        .iter()
+        .map(|tx| {
+            (
+                tx,
+                Transaction::read(
+                    Cursor::new(hex::decode(tx).map_err(|_| "Tx hex is invalid").unwrap()),
+                    pivx_primitives::consensus::BranchId::Sapling,
+                )
+                .map_err(|_| "Couldn't parse tx")
+                .unwrap(),
+            )
+        })
+        .collect::<Vec<_>>();
+    let decrypted_txs = maybe_iter!(txs)
+        .map(|(_, tx)| {
+            if is_testnet {
+                decrypt_transaction(&TEST_NETWORK, BlockHeight::from_u32(320), tx, &hash)
+            } else {
+                decrypt_transaction(&MAIN_NETWORK, BlockHeight::from_u32(320), tx, &hash)
+            }
+        })
+        .collect::<Vec<_>>();
     let mut nullifiers = vec![];
     let mut new_notes = vec![];
     let mut wallet_transactions = vec![];
-    for block in blocks {
-        for tx in block.txs {
-            let old_note_length = new_notes.len();
-            let tx_nullifiers = handle_transaction(
-                &mut tree,
-                &tx,
-                key.clone(),
-                is_testnet,
-                &mut comp_note,
-                &mut new_notes,
-            )
-            .map_err(|_| "Couldn't handle transaction")?
-            .into_iter()
-            .map(|n| hex::encode(n.0))
-            .collect::<Vec<_>>();
-            let mut is_wallet_tx = old_note_length != new_notes.len();
-            for n in comp_note.iter().chain(new_notes.iter()) {
-                if is_wallet_tx || tx_nullifiers.contains(&n.nullifier) {
-                    is_wallet_tx = true;
-                    break;
-                }
+    for (&(hex, ref tx), decrypted_tx) in txs.iter().zip(decrypted_txs) {
+        let old_note_length = new_notes.len();
+        let tx_nullifiers = handle_transaction(
+            &mut tree,
+            tx,
+            &decrypted_tx,
+            &nullif_key,
+            &mut comp_note,
+            &mut new_notes,
+        )
+        .map_err(|_| "Couldn't handle transaction")?
+        .into_iter()
+        .map(|n| hex::encode(n.0))
+        .collect::<Vec<_>>();
+        let mut is_wallet_tx = old_note_length != new_notes.len();
+        for n in comp_note.iter().chain(new_notes.iter()) {
+            if is_wallet_tx || tx_nullifiers.contains(&n.nullifier) {
+                is_wallet_tx = true;
+                break;
             }
-            if is_wallet_tx {
-                wallet_transactions.push(tx);
-            }
-            nullifiers.extend(tx_nullifiers);
         }
+        if is_wallet_tx {
+            wallet_transactions.push(hex.to_string());
+        }
+        nullifiers.extend(tx_nullifiers);
     }
 
     let ser_comp_note = serialize_comp_note(comp_note).map_err(|_| "couldn't decrypt notes")?;
@@ -229,27 +275,12 @@ pub fn serialize_comp_note(
 //add a tx to a given commitment tree and the return a witness to each output
 pub fn handle_transaction(
     tree: &mut CommitmentTree<Node, DEPTH>,
-    tx: &str,
-    key: UnifiedFullViewingKey,
-    is_testnet: bool,
+    tx: &Transaction,
+    decrypted_tx: &DecryptedTransaction<'_, AccountId>,
+    nullif_key: &NullifierDerivingKey,
     witnesses: &mut [SpendableNote],
     new_witnesses: &mut Vec<SpendableNote>,
 ) -> Result<Vec<Nullifier>, Box<dyn Error>> {
-    let tx = Transaction::read(
-        Cursor::new(hex::decode(tx)?),
-        pivx_primitives::consensus::BranchId::Sapling,
-    )?;
-    let mut hash = HashMap::new();
-    let nullif_key = key
-        .sapling()
-        .ok_or("Cannot generate nullifier key")?
-        .to_nk(Scope::External);
-    hash.insert(AccountId::default(), key);
-    let decrypted_tx = if is_testnet {
-        decrypt_transaction(&TEST_NETWORK, BlockHeight::from_u32(320), &tx, &hash)
-    } else {
-        decrypt_transaction(&MAIN_NETWORK, BlockHeight::from_u32(320), &tx, &hash)
-    };
     let mut nullifiers: Vec<Nullifier> = vec![];
     if let Some(sapling) = tx.sapling_bundle() {
         for x in sapling.shielded_spends() {
@@ -272,7 +303,7 @@ pub fn handle_transaction(
                 if index == i {
                     // Save witness
                     let witness = IncrementalWitness::<Node, DEPTH>::from_tree(tree.clone());
-                    let nullifier = get_nullifier_from_note_internal(&nullif_key, note, &witness)?;
+                    let nullifier = get_nullifier_from_note_internal(nullif_key, note, &witness)?;
                     let memo = Memo::from_bytes(output.memo().as_slice())
                         .map(|m| {
                             if let Memo::Text(e) = m {

--- a/src/transaction/test.rs
+++ b/src/transaction/test.rs
@@ -1,5 +1,7 @@
 #![cfg(test)]
 
+use crate::transaction::decrypt_transaction;
+use crate::transaction::*;
 use crate::transaction::{
     create_transaction_internal, get_nullifier_from_note_internal, SpendableNote, TxInternalArgs,
 };
@@ -38,9 +40,28 @@ fn check_tx_decryption() {
         skey.to_extended_full_viewing_key(),
     )
     .expect("Failed to create key");
+    let nullif_key = key
+        .sapling()
+        .unwrap()
+        .to_nk(Scope::External);
     let mut new_comp_note = vec![];
-    let nullifiers =
-        handle_transaction(&mut tree, tx, key, true, &mut vec![], &mut new_comp_note).unwrap();
+    let mut hash = HashMap::new();
+    hash.insert(AccountId::default(), key.clone());
+    let tx = Transaction::read(
+        Cursor::new(hex::decode(tx).unwrap()),
+        pivx_primitives::consensus::BranchId::Sapling,
+    )
+    .unwrap();
+    let decrypted_tx = decrypt_transaction(&TEST_NETWORK, BlockHeight::from_u32(320), &tx, &hash);
+    let nullifiers = handle_transaction(
+        &mut tree,
+        &tx,
+        &decrypted_tx,
+        &nullif_key,
+        &mut vec![],
+        &mut new_comp_note,
+    )
+    .unwrap();
     //This was a t-s tx
     assert_eq!(nullifiers.len(), 0);
     //Successfully decrypt exactly 1 note
@@ -94,11 +115,25 @@ pub async fn test_create_transaction() -> Result<(), Box<dyn Error>> {
     let input_tx = "0300000001a347f398c8957afee7ef0fae759ff29feda25f3e72ab5052ea09729389fd48ca000000006b483045022100c332effdceaa20b3225d52d20059e443ed112d561329b81f78a9db338637e6a102204f948d70c37bfe96bbe776f8279ad5fa857c638338d8ce49f553a3ec60993d8f0121025c6802ec58464d8e65d5f01be0b7ce6e8404e4a99f28ea3bfe47efe40df9108cffffffff01e89bd55a050000001976a9147888a1affe25e5c7af03fffdbea29f13ee1be22b88ac0000000001006cca88ffffffff000150585de8e31e6c65dfa07981275f13ebb8c9c67d8c7d088622aacca6c35c67a23642ad16653acda3cf9b5230f652592197e578ea1eae78c2496a3dc274a4ba0b522216af4c44abd4e9b81964d0a801929df1cb543c4fea041d056cc493b2f8dd90db662a0a43dae4d80a8cb0bd93e22b7000c0bcdab93f94800b88268a78a4d77147f2f16bde98b2386e5ac4025260df5f63adaef13bc8d7a920dbd14fa7e8ef0c5ff29f00942341e29b15509bfa99b4b1bd0ba29c5cf2c419113c27288b3a8d8f4919a4845e47d4e5fe1d1081a98e0ee49bb0e422b339e949276a1264c236850d9beb94c7855143a4f00689d1bf8d996eee9f0ee865ca780713f5aa1990aa848d47a39ea45c926141a1ff5a5a45c2e2e78d470a180e02b3dd47e0b206a4542d4dbfc540023ee5cb35e54a086942657232c27a15c87eef6dd11587e871ea690a45002e0b60605d7c4ac7fde81a71aadde9d0cc0d5c347fbe942993bd2a69ca2ca98ea0885454e7387d609192094bea075b96f020a8ed7080b5ef0aaf13e73da67a68e377db62720724e8c0d2913487be2a3e39380b33a90f0336f07fa031345a42784460356987da3227bd40a8cf933e4b8661020cf566af785a5c9b404c84153a69d9280739cb567c6cdf41f7a1a38b4d5847b33956b4dfa847b386850eff2a3e9fe7434fb551d1c6d31fae868a2f491ebd4f382a0ac203652f4be9fb3cff3ed10e6295639af76a41e40e562862d4359e4874b565aa1bae4b68abb0a7fe66884b75250d16276521925ead4821c7f04338286c2e52e7772f980d7a228ad2b89c18c8eeaf3ee1b4d5c5a959fc93c1cda3f9340f8256a88076b96a8718efc5dcb3733e3e11f6ca1198a97a248ff4ab0a7e883e360b8495470badc7ec75f84e58d87ff83d03c594a11b9029177efa5fea026a71c2c328a6356bd447eb154ac39e43963118033fc1a72702b12e641e7dfa8f98a58e43d75f6b3350af9fc54e683c6074cfd76e86752d7f598b6816696a4f17ba5f10c983ad2f8e102f44f42b2d07b24fb599abbfd067373c4b00f9ae830fcdd79ca8fa8c90eb414f8f5bb070d1199b9e9fae7124772865e0d6f486d7f10f073a0d61bd9e8c94b7a963c831e76b5c07cef22c06877a683aca53396289b115f8b59989f3d5906c4961891ef4677ce73d752ee0ba8929056f38d7630b02db2188d512d733126fa2479217dcd5ed4061928e5ba374300d7a5fa08af2b64cbf5a2176e07b3a4a5bb4812c46c2e608d364d8589225f9b7620116e0cd6a175ab397d295ff0ee0100d2415db6c6736a0f6e2248a62c4c47b39103f67e30814cf3c9b0b82936546d4b81826cd8fdebe24ae91a81b69e7188f4b18c3422d61b367bc4ca92f8815c0fc42caf524b3337a8b9a6737557e1d471745e02a8e88a19fe730e224126d290a";
 
     let mut new_notes = vec![];
+
+    let nullif_key = key
+        .sapling()
+        .unwrap()
+        .to_nk(Scope::External);
+    let mut hash = HashMap::new();
+    hash.insert(AccountId::default(), key.clone());
+    let tx = Transaction::read(
+        Cursor::new(hex::decode(input_tx).unwrap()),
+        pivx_primitives::consensus::BranchId::Sapling,
+    )
+    .unwrap();
+    let decrypted_tx = decrypt_transaction(&TEST_NETWORK, BlockHeight::from_u32(320), &tx, &hash);
+
     let _nullifiers = handle_transaction(
         &mut commitment_tree,
-        input_tx,
-        key,
-        true,
+        &tx,
+	&decrypted_tx,
+        &nullif_key,
         &mut vec![],
         &mut new_notes,
     )?;


### PR DESCRIPTION
Improve shield sync time by parallelizing the decryption process of transactions when the multicore feature is enabled.
This sped up syncing time on MPW by about 50% on my desktop computer, the effect might not be as great on devices with fewer CPU cores